### PR TITLE
Troubleshoot HACS integration download failures

### DIFF
--- a/custom_components/openai_conversation_plus/manifest.json
+++ b/custom_components/openai_conversation_plus/manifest.json
@@ -14,5 +14,5 @@
 	"requirements": [
 		"openai~=1.76.2"
 	],
-	"version": "2025.81.1"
+	"version": "2025.81.2"
 }

--- a/hacs.json
+++ b/hacs.json
@@ -1,9 +1,7 @@
 {
   "name": "OpenAI Conversation Plus",
   "content_in_root": false,
-  "filename": "openai_conversation_plus.zip",
   "render_readme": true,
-  "zip_release": true,
   "hide_default_branch": false,
   "homeassistant": "2025.8.3",
   "persistent_directory": "custom_components/openai_conversation_plus",


### PR DESCRIPTION
Remove `zip_release` and `filename` from `hacs.json` and bump `manifest.json` version to fix HACS 404 download errors.

---
<a href="https://cursor.com/background-agent?bcId=bc-7c371c38-2c9f-4837-9dfb-d03eb29ee7a0">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-7c371c38-2c9f-4837-9dfb-d03eb29ee7a0">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

