### PR TITLE
Investigate and fix integration function call failures

### DIFF
--- a/custom_components/openai_conversation_plus/__init__.py
+++ b/custom_components/openai_conversation_plus/__init__.py
@@ -566,11 +566,13 @@ class OpenAIAgent(conversation.AbstractConversationAgent):
                 responses_function_tools.append(
                     {
                         "type": "function",
-                        "name": func.get("name"),
-                        "description": func.get("description", ""),
-                        "parameters": func.get(
-                            "parameters", {"type": "object", "properties": {}}
-                        ),
+                        "function": {
+                            "name": func.get("name"),
+                            "description": func.get("description", ""),
+                            "parameters": func.get(
+                                "parameters", {"type": "object", "properties": {}}
+                            ),
+                        },
                     }
                 )
 
@@ -651,12 +653,13 @@ class OpenAIAgent(conversation.AbstractConversationAgent):
             for tool in api_tools:
                 tool_type = tool.get("type")
                 if tool_type == "function":
-                    # Must have top-level name for Responses API
-                    if tool.get("name"):
+                    # Must have nested function with name for Responses API
+                    fn = tool.get("function") or {}
+                    if isinstance(fn, dict) and fn.get("name"):
                         validated_tools.append(tool)
                     else:
                         _LOGGER.warning(
-                            "[v%s] Skipping function tool without top-level name: %s",
+                            "[v%s] Skipping function tool without required function.name: %s",
                             INTEGRATION_VERSION,
                             tool,
                         )

--- a/custom_components/openai_conversation_plus/const.py
+++ b/custom_components/openai_conversation_plus/const.py
@@ -147,7 +147,7 @@ DEFAULT_CONF_FUNCTIONS = [
 CONF_ATTACH_USERNAME = "attach_username"
 DEFAULT_ATTACH_USERNAME = False
 CONF_USE_TOOLS = "use_tools"
-DEFAULT_USE_TOOLS = False
+DEFAULT_USE_TOOLS = True
 # Truncation-related constants removed; ChatLog is source of truth for history
 
 SERVICE_QUERY_IMAGE = "query_image"

--- a/custom_components/openai_conversation_plus/conversation.py
+++ b/custom_components/openai_conversation_plus/conversation.py
@@ -76,9 +76,11 @@ class OpenAIConversationEntity(
                 tools.append(
                     {
                         "type": "function",
-                        "name": t.name,
-                        "description": getattr(t, "description", ""),
-                        "parameters": getattr(t, "parameters", {}),
+                        "function": {
+                            "name": t.name,
+                            "description": getattr(t, "description", ""),
+                            "parameters": getattr(t, "parameters", {}),
+                        },
                     }
                 )
         


### PR DESCRIPTION
Enable function tools by default and update the tool schema to match the Responses API's nested 'function' structure.

Function calls were failing because `use_tools` was set to `False` by default, preventing tool definitions from being sent. Additionally, the Responses API now expects function tools to be defined with a nested `function` key (e.g., `{'type': 'function', 'function': {'name': '...', ...}}`), which the integration was not providing.

---
<a href="https://cursor.com/background-agent?bcId=bc-9428739f-dd3c-4ef3-9e25-ecb0b9527fb2">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-9428739f-dd3c-4ef3-9e25-ecb0b9527fb2">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

