### PR TITLE
Fix openai invalid parameter error

### DIFF
--- a/custom_components/openai_conversation_plus/__init__.py
+++ b/custom_components/openai_conversation_plus/__init__.py
@@ -825,7 +825,10 @@ class OpenAIAgent(conversation.AbstractConversationAgent):
                         # Ensure require_approval is set (default to "never" if missing)
                         if "require_approval" not in tool:
                             tool["require_approval"] = "never"
-                        validated_tools.append(tool)
+                        # Remove server_api_key before sending to OpenAI (not supported by Responses API)
+                        # The API key should be stored separately for use when calling the MCP server
+                        mcp_tool = {k: v for k, v in tool.items() if k != "server_api_key"}
+                        validated_tools.append(mcp_tool)
                     else:
                         _LOGGER.warning(
                             "[v%s] Skipping MCP tool without required fields (server_label, server_url): %s",

--- a/custom_components/openai_conversation_plus/conversation.py
+++ b/custom_components/openai_conversation_plus/conversation.py
@@ -139,7 +139,11 @@ class OpenAIConversationEntity(
         if mcp_tools:
             if tools is None:
                 tools = []
-            tools.extend(mcp_tools)
+            # Filter out server_api_key before sending to OpenAI (not supported by Responses API)
+            for mcp_tool in mcp_tools:
+                # Remove server_api_key from MCP tools before adding
+                clean_tool = {k: v for k, v in mcp_tool.items() if k != "server_api_key"}
+                tools.append(clean_tool)
 
         # Build Responses API input from chat log
         msgs: list[dict[str, Any]] = []


### PR DESCRIPTION
Remove `server_api_key` from MCP tools before sending them to OpenAI's API to resolve `BadRequestError` due to an unknown parameter.

---
<a href="https://cursor.com/background-agent?bcId=bc-0ee1876a-8e41-47da-bd93-9bfbf9bd69a1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-0ee1876a-8e41-47da-bd93-9bfbf9bd69a1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

